### PR TITLE
Fix linter errors and consistency issues

### DIFF
--- a/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
+++ b/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
@@ -211,7 +211,7 @@ Table 2: Recommended compiler options that enable run-time protection mechanisms
 | [`-fno-strict-aliasing`](#-fno-strict-aliasing)                                           | GCC 2.95.3<br/>Clang 18.0.0        | Do not assume strict aliasing                                                                |
 | [`-ftrivial-auto-var-init`](#-ftrivial-auto-var-init)                                     | GCC 12<br/>Clang 8.0               | Perform trivial auto variable initialization                                                 |
 | [`-fexceptions`](#-fexceptions)                                                           | GCC 2.95.3<br/>Clang 2.6           | Enable exception propagation to harden multi-threaded C code                                 |
-| [`-fvtable-verify=std`](#-fvtable-verify)                                                 | GCC 4.9.4                          | (C++) Enable run-time checks for virtual function pointers corruption. Significantly impacts performance.|
+| [`-fvtable-verify=std`](#-fvtable-verify)                                                 | GCC 4.9.4                          | Enable run-time checks for C++ virtual function pointers corruption. Significantly impacts performance.|
 
 [^Guelton20]: The implementation of `-D_FORTIFY_SOURCE={1,2,3}` in the GNU libc (glibc) relies heavily on implementation details within GCC. Clang implements its own style of fortified function calls (originally introduced for Android’s bionic libc) but as of Clang / LLVM 14.0.6 incorrectly produces non-fortified calls to some glibc functions with `_FORTIFY_SOURCE` . Code set to be fortified with Clang will still compile, but may not always benefit from the fortified function variants in glibc. For more information see: Guelton, Serge, [Toward _FORTIFY_SOURCE parity between Clang and GCC. Red Hat Developer](https://developers.redhat.com/blog/2020/02/11/toward-_fortify_source-parity-between-clang-and-gcc), Red Hat Developer, 2020-02-11 and Poyarekar, Siddhesh, [D91677 Avoid simplification of library functions when callee has an implementation](https://reviews.llvm.org/D91677), LLVM Phabricator, 2020-11-17.
 
@@ -988,13 +988,13 @@ The `-fexceptions` option is also needed for C code that needs to interoperate w
 
 ---
 
-### Enable run-time checks for virtual function pointers corruption
+### Enable run-time checks for C++ virtual function pointers corruption
 
-| Compiler Flag                                                       | Supported since     | Description                                  |
-|:--------------------------------------------------------------------|:-------------------:|:---------------------------------------------|
-| <span id="-fvtable-verify">`-fvtable-verify=std`</span> | GCC 4.9.4 | (C++) Enable run-time checks for virtual function pointers corruption after shared libraries have been loaded. Significantly impacts performance.. |
-| <span id="-fvtable-verify">`-fvtable-verify=preinit`</span> | GCC 4.9.4 | (C++) Enable run-time checks for virtual function pointers corruption before shared libraries have been loaded. Significantly impacts performance. |
-| <span id="-fvtable-verify">`-fvtable-verify=none`</span> | GCC 4.9.4 | (C++) Disable enable run-time checks for virtual function pointers corruption. |
+| Compiler Flag                                               | Supported since  | Description                                                                                                    |
+|:------------------------------------------------------------|:----------------:|:---------------------------------------------------------------------------------------------------------------|
+| <span id="-fvtable-verify">`-fvtable-verify=std`</span>     | GCC 4.9.4        | Enable run-time checks for C++ virtual function pointers corruption after shared libraries have been loaded  |
+| <span id="-fvtable-verify">`-fvtable-verify=preinit`</span> | GCC 4.9.4        | Enable run-time checks for C++ virtual function pointers corruption before shared libraries have been loaded |
+| <span id="-fvtable-verify">`-fvtable-verify=none`</span>    | GCC 4.9.4        | Disable enable run-time checks for C++ virtual function pointers corruption.                                 |
 
 #### Synopsis
 

--- a/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
+++ b/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
@@ -1000,7 +1000,7 @@ The `-fexceptions` option is also needed for C code that needs to interoperate w
 
 In object-oriented programming, object methods rely on dynamic dispatching to select the right virtual function to call at runtime. The vtable is the table of virtual function pointers linked to the code of the virtual function to be executed. The vtable can be overwritten by vtable hijacking attack. This option is used to check, at runtime, that each virtual function call is valid for its object type. This check prevents virtual function pointers from being corrupted or overwritten, and stops the application (SIGABRT) if the pointer integrity check fails. This virtual table pointer check is based on the data structure built at application start-up.
 
-This option has three choices [^gccvtv]:
+This option has three choices[^gccvtv]:
 
 - `std` - Built after shared libraries have been loaded and initialized, vtable data imply to process check at normal object initialization time.
 - `preinit` - Built before shared libraries have been loaded and initialized, vtable data enable check before shared libraries are loaded to process check at early execution time.
@@ -1010,15 +1010,15 @@ This option has three choices [^gccvtv]:
 
 ### Performance implications
 
-Caroline Tice played an important role in integrating the vtable verification (VTV) by submitting the commit of this feature in GCC 4.9 [^gccvtvcommit]. She involved on articles that give information about performance penalty. She is describe performance penalty following 3 points: 
+Caroline Tice played an important role in integrating the vtable verification (VTV) by submitting the commit of this feature in GCC 4.9[^gccvtvcommit]. She involved on articles that give information about performance penalty. She is describe performance penalty following 3 points:
 
 - Call verification: Performance penalty between 5% and 10%.
-- Object permission changes: Between 400% and 700% slowdown for permission changes per object file, while a performance loss of 320 ms is noticeable for permission changes per binary. 
+- Object permission changes: Between 400% and 700% slowdown for permission changes per object file, while a performance loss of 320 ms is noticeable for permission changes per binary.
 - Virtual function hashtable size: Storage of virtual function hashtable imply a big waste of space.
 
 Detailed information on virtual table verification and performance penalties can be found in Caroline Tice's GNU Tools Cauldron 2012 talk[^Tice2012] and USENIX Security '14 article[^Tice2014].
 
-In addition to this performance penalty information, GCC's virtual table checking function is tracked by the `-fvtv-counts` flag [^gccvtvcount], which provides counters to evaluate the number of virtual calls checked and the size of virtual table pointer sets for each class. These counters are useful information for assessing the performance penalty on source code. This information is written to two log files:
+In addition to this performance penalty information, GCC's virtual table checking function is tracked by the `-fvtv-counts` flag[^gccvtvcount], which provides counters to evaluate the number of virtual calls checked and the size of virtual table pointer sets for each class. These counters are useful information for assessing the performance penalty on source code. This information is written to two log files:
 
 - `vtv_count_data.log` - The number of virtual calls being verified for each class.
 - `vtv_class_set_sizes.log` - The size of the vtable pointer sets for each class.
@@ -1034,7 +1034,7 @@ Virtual table verification is disabled in the default GCC configuration. GCC mus
 
 Virtual table checking can lead to failures due to incomplete data when a binary is compiled without virtual table checking but linked to libraries compiled with virtual table checking. The `libvtv_stubs` library is available for the linker to disable virtual table checking on libraries compiled without table verification flag.
 
-Additional debugging information is also available using GCC's `-fvtv-debug` flag [^gccvtvdebug]. This flag provides information on binaries compiled with `-fvtable-verify` to gain a better understanding of the action during virtual table verification. It traces the virtual table pointers checked for each class of source code in a log file (vtv_set_ptr_data.log).
+Additional debugging information is also available using GCC's `-fvtv-debug` flag[^gccvtvdebug]. This flag provides information on binaries compiled with `-fvtable-verify` to gain a better understanding of the action during virtual table verification. It traces the virtual table pointers checked for each class of source code in a log file (vtv_set_ptr_data.log).
 
 The location of `-fvtv-counts` and `-fvtv-debug` log files is defined by the `VTV_LOGS_DIR` environment variable. The default location is the current directory.
 

--- a/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
+++ b/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
@@ -1030,7 +1030,7 @@ In addition to this performance penalty information, GCC's virtual table checkin
 
 ### Additional Considerations
 
-Virtual table verification is disabled in the default GCC configuration. GCC must be compiled with the `--enable-vtable-verify` option to enable virtual table verification. The current GCC configuration is given by `gcc -v` or `gcc -###` command.
+Virtual table verification is disabled in the default GCC configuration. GCC must be compiled with the `--enable-vtable-verify` option to enable virtual table verification[^gccvtvenable]. The current GCC configuration is given by `gcc -v` or `gcc -###` command.
 
 Virtual table checking can lead to failures due to incomplete data when a binary is compiled without virtual table checking but linked to libraries compiled with virtual table checking. The `libvtv_stubs` library is available for the linker to disable virtual table checking on libraries compiled without table verification flag.
 

--- a/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
+++ b/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.md
@@ -1016,15 +1016,15 @@ Caroline Tice played an important role in integrating the vtable verification (V
 - Object permission changes: Between 400% and 700% slowdown for permission changes per object file, while a performance loss of 320 ms is noticeable for permission changes per binary. 
 - Virtual function hashtable size: Storage of virtual function hashtable imply a big waste of space.
 
-Detailed information on virtual table verification and performance penalties can be found in Caroline Tice's articles. [^ticecauldrom2012][^usenixsec14]
+Detailed information on virtual table verification and performance penalties can be found in Caroline Tice's GNU Tools Cauldron 2012 talk[^Tice2012] and USENIX Security '14 article[^Tice2014].
 
 In addition to this performance penalty information, GCC's virtual table checking function is tracked by the `-fvtv-counts` flag [^gccvtvcount], which provides counters to evaluate the number of virtual calls checked and the size of virtual table pointer sets for each class. These counters are useful information for assessing the performance penalty on source code. This information is written to two log files:
 
 - `vtv_count_data.log` - The number of virtual calls being verified for each class.
 - `vtv_class_set_sizes.log` - The size of the vtable pointer sets for each class.
 
-[^ticecauldrom2012]: Tice, Caroline, [Improving Function Pointer Security for Virtual Method Dispatches](https://gcc.gnu.org/wiki/cauldron2012?action=AttachFile&do=get&target=cmtice.pdf#page=38), Google, Inc., July 2012.
-[^usenixsec14]: Tice, Caroline, [Enforcing Forward-Edge Control-Flow Integrity in GCC & LLVM](https://www.usenix.org/sites/default/files/conference/protected-files/sec14_slides_tice.pdf#page=14), Google, Inc., July 2012.
+[^Tice2012]: Tice, Caroline, [Improving Function Pointer Security for Virtual Method Dispatches](https://gcc.gnu.org/wiki/cauldron2012?action=AttachFile&do=get&target=cmtice.pdf#page=38), GNU Tools Cauldron, July 2012.
+[^Tice2014]: Tice, Caroline, [Enforcing Forward-Edge Control-Flow Integrity in GCC & LLVM](https://www.usenix.org/system/files/conference/usenixsecurity14/sec14-paper-tice.pdf), USENIX Security, August 2014.
 [^gccvtvcount]: Team GCC, [Program Instrumentation Options: `-fvtv-counts`](https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html#index-fvtv-counts), GCC Manual, August 2013
 [^gccvtvcommit]: Tice, Caroline, [Commit the vtable verification feature](https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=2077db1be5b18b94a91095a3fb380bbc4a81e61b), GCC GIT, August 2013
 


### PR DESCRIPTION
- Add C++ to `-fvtable-verify` section title
- Use consistent wording in all -fvtable-verify option table entries
- Adjust Markdown table layout in `-fvtable-verify` section
- Adjust citations to `-vtable-verify` talks and articles
  - Adjust labels to `^Tice2012` and `^Tice2014` to be consistent with citation style elsewhere in the guide
   - Change URL for Usenix Security '14 material to point to article as suggested by the text
   - Adjust references to `[^Tice2012]` and `[^Tice2014]` to avoid linter  errors
   - Add citation to `[^gccvtvenble]` to avoid linter error
 - Remove unnecessary spaces in `-fvtable-verify` description